### PR TITLE
Introduce a @serialize directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,18 @@ The key can be expressed via the `@serialize(key: …)` directive:
 mutation favoriteIsRed @serialize(key: "favoriteColor") {
     setFavoriteColor(color: "RED)
 }
+```
 
+```graphql
 # …or it can be a variable in the operation…
 mutation upvotePost($id: ID!) @serialize(key: $id) {
     post(id: $id) {
         addVote
     }
 }
+```
 
+```graphql
 # …and finally, it also supports interpolation:
 mutation upvotePost($id: ID!) @serialize(key: "post:{{id}}") {
     post(id: $id) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.0",
   "description": "A link that serializes requests by key, making sure that they execute in the exact order submitted",
   "dependencies": {
-    "apollo-link": "^0.7.0"
+    "apollo-link": "^0.7.0",
+    "deep-update": "^1.3.4"
   },
   "devDependencies": {
     "@types/graphql": "^0.11.7",

--- a/src/SerializingLink.ts
+++ b/src/SerializingLink.ts
@@ -7,6 +7,8 @@ import {
     FetchResult,
 } from 'apollo-link';
 
+import { extractKey } from './extractKey';
+
 export interface OperationQueueEntry {
     operation: Operation;
     forward: NextLink;
@@ -20,8 +22,8 @@ export interface OperationQueueEntry {
 export default class SerializingLink extends ApolloLink {
     private opQueues: { [key: string]: OperationQueueEntry[] } = {};
 
-    public request(operation: Operation, forward: NextLink ) {
-        const key = this.keyForOperation(operation);
+    public request(origOperation: Operation, forward: NextLink ) {
+        const { operation, key } = extractKey(origOperation);
         if (!key) {
             return forward(operation);
         }
@@ -94,9 +96,5 @@ export default class SerializingLink extends ApolloLink {
                 this.dequeue(key);
             },
         });
-    }
-
-    private keyForOperation = (operation: Operation): string => {
-        return operation.getContext().serializationKey;
     }
 }

--- a/src/SerializingLink.ts
+++ b/src/SerializingLink.ts
@@ -21,10 +21,11 @@ export default class SerializingLink extends ApolloLink {
     private opQueues: { [key: string]: OperationQueueEntry[] } = {};
 
     public request(operation: Operation, forward: NextLink ) {
-        if (!operation.getContext().serializationKey) {
+        const key = this.keyForOperation(operation);
+        if (!key) {
             return forward(operation);
         }
-        const key = operation.getContext().serializationKey;
+
         return new Observable(observer => {
             this.enqueue(key, { operation, forward, observer });
 
@@ -93,5 +94,9 @@ export default class SerializingLink extends ApolloLink {
                 this.dequeue(key);
             },
         });
+    }
+
+    private keyForOperation = (operation: Operation): string => {
+        return operation.getContext().serializationKey;
     }
 }

--- a/src/extractKey.test.ts
+++ b/src/extractKey.test.ts
@@ -1,0 +1,111 @@
+import { createOperation } from 'apollo-link';
+import gql from 'graphql-tag';
+import { OperationDefinitionNode } from 'graphql';
+
+import { extractKey } from './extractKey';
+
+describe('extractKey', () => {
+  it('prefers context.serializationKey if the directive is also supplied', () => {
+    const origOperation = createOperation({ serializationKey: 'foo' }, {
+      query: gql`
+        mutation doThing @serialize(key: "bar") {
+          doThing
+        }
+      `,
+    });
+    const { operation, key } = extractKey(origOperation);
+
+    expect(key).toEqual('foo');
+    expect(operation).toBe(origOperation);
+  });
+
+  it('asserts that the key argument is present', () => {
+    expect(() => {
+      const origOperation = createOperation(null, {
+        query: gql`
+          mutation doThing @serialize {
+            doThing
+          }
+        `,
+      });
+      extractKey(origOperation);
+    }).toThrow(/@serialize.*key/);
+  });
+
+  it('asserts that the key argument is a string or variable', () => {
+    expect(() => {
+      const origOperation = createOperation(null, {
+        query: gql`
+          mutation doThing @serialize(key: 123) {
+            doThing
+          }
+        `,
+      });
+      extractKey(origOperation);
+    }).toThrow(/@serialize.*key/);
+  });
+
+  it('supports literal keys via @serialize', () => {
+    const origOperation = createOperation(null, {
+      query: gql`
+        mutation doThing @serialize(key: "bar") {
+          doThing
+        }
+      `,
+    });
+    const { operation, key } = extractKey(origOperation);
+
+    expect(key).toEqual('bar');
+    expect(operation).not.toBe(origOperation);
+  });
+
+  it('supports direct variables via @serialize', () => {
+    const origOperation = createOperation(null, {
+      query: gql`
+        mutation doThing($var: String) @serialize(key: $var) {
+          doThing
+        }
+      `,
+      variables: {
+        var: 'bar',
+      },
+    });
+    const { operation, key } = extractKey(origOperation);
+
+    expect(key).toEqual('bar');
+    expect(operation).not.toBe(origOperation);
+  });
+
+  it('removes @serialize from the query document', () => {
+    const origOperation = createOperation(null, {
+      query: gql`
+        mutation doThing @serialize(key: "bar") @fizz {
+          doThing
+        }
+      `,
+    });
+    const { operation, key } = extractKey(origOperation);
+
+    const operationNode = operation.query.definitions[0] as OperationDefinitionNode;
+    expect(operationNode.directives.length).toEqual(1);
+    expect(operationNode.directives[0].name.value).toEqual('fizz');
+  });
+
+  it('interpolates variables within a string', () => {
+    const origOperation = createOperation(null, {
+      query: gql`
+        mutation doThing($id: Integer, $oid: String) @serialize(key: "thing:{{id}}:{{oid}}") @fizz {
+          doThing
+        }
+      `,
+      variables: {
+        id: 123,
+        oid: 'foo',
+      },
+    });
+    const { operation, key } = extractKey(origOperation);
+
+    expect(key).toEqual('thing:123:foo');
+    expect(operation).not.toBe(origOperation);
+  });
+});

--- a/src/extractKey.test.ts
+++ b/src/extractKey.test.ts
@@ -5,107 +5,107 @@ import { OperationDefinitionNode } from 'graphql';
 import { extractKey } from './extractKey';
 
 describe('extractKey', () => {
-  it('prefers context.serializationKey if the directive is also supplied', () => {
-    const origOperation = createOperation({ serializationKey: 'foo' }, {
-      query: gql`
-        mutation doThing @serialize(key: "bar") {
-          doThing
-        }
-      `,
+    it('prefers context.serializationKey if the directive is also supplied', () => {
+        const origOperation = createOperation({ serializationKey: 'foo' }, {
+            query: gql`
+                mutation doThing @serialize(key: "bar") {
+                    doThing
+                }
+            `,
+        });
+        const { operation, key } = extractKey(origOperation);
+
+        expect(key).toEqual('foo');
+        expect(operation).toBe(origOperation);
     });
-    const { operation, key } = extractKey(origOperation);
 
-    expect(key).toEqual('foo');
-    expect(operation).toBe(origOperation);
-  });
-
-  it('asserts that the key argument is present', () => {
-    expect(() => {
-      const origOperation = createOperation(null, {
-        query: gql`
-          mutation doThing @serialize {
-            doThing
-          }
-        `,
-      });
-      extractKey(origOperation);
-    }).toThrow(/@serialize.*key/);
-  });
-
-  it('asserts that the key argument is a string or variable', () => {
-    expect(() => {
-      const origOperation = createOperation(null, {
-        query: gql`
-          mutation doThing @serialize(key: 123) {
-            doThing
-          }
-        `,
-      });
-      extractKey(origOperation);
-    }).toThrow(/@serialize.*key/);
-  });
-
-  it('supports literal keys via @serialize', () => {
-    const origOperation = createOperation(null, {
-      query: gql`
-        mutation doThing @serialize(key: "bar") {
-          doThing
-        }
-      `,
+    it('asserts that the key argument is present', () => {
+        expect(() => {
+            const origOperation = createOperation(null, {
+                query: gql`
+                    mutation doThing @serialize {
+                        doThing
+                    }
+                `,
+            });
+            extractKey(origOperation);
+        }).toThrow(/@serialize.*key/);
     });
-    const { operation, key } = extractKey(origOperation);
 
-    expect(key).toEqual('bar');
-    expect(operation).not.toBe(origOperation);
-  });
-
-  it('supports direct variables via @serialize', () => {
-    const origOperation = createOperation(null, {
-      query: gql`
-        mutation doThing($var: String) @serialize(key: $var) {
-          doThing
-        }
-      `,
-      variables: {
-        var: 'bar',
-      },
+    it('asserts that the key argument is a string or variable', () => {
+        expect(() => {
+            const origOperation = createOperation(null, {
+                query: gql`
+                    mutation doThing @serialize(key: 123) {
+                        doThing
+                    }
+                `,
+            });
+            extractKey(origOperation);
+        }).toThrow(/@serialize.*key/);
     });
-    const { operation, key } = extractKey(origOperation);
 
-    expect(key).toEqual('bar');
-    expect(operation).not.toBe(origOperation);
-  });
+    it('supports literal keys via @serialize', () => {
+        const origOperation = createOperation(null, {
+            query: gql`
+                mutation doThing @serialize(key: "bar") {
+                    doThing
+                }
+            `,
+        });
+        const { operation, key } = extractKey(origOperation);
 
-  it('removes @serialize from the query document', () => {
-    const origOperation = createOperation(null, {
-      query: gql`
-        mutation doThing @serialize(key: "bar") @fizz {
-          doThing
-        }
-      `,
+        expect(key).toEqual('bar');
+        expect(operation).not.toBe(origOperation);
     });
-    const { operation, key } = extractKey(origOperation);
 
-    const operationNode = operation.query.definitions[0] as OperationDefinitionNode;
-    expect(operationNode.directives.length).toEqual(1);
-    expect(operationNode.directives[0].name.value).toEqual('fizz');
-  });
+    it('supports direct variables via @serialize', () => {
+        const origOperation = createOperation(null, {
+            query: gql`
+                mutation doThing($var: String) @serialize(key: $var) {
+                    doThing
+                }
+            `,
+            variables: {
+                var: 'bar',
+            },
+        });
+        const { operation, key } = extractKey(origOperation);
 
-  it('interpolates variables within a string', () => {
-    const origOperation = createOperation(null, {
-      query: gql`
-        mutation doThing($id: Integer, $oid: String) @serialize(key: "thing:{{id}}:{{oid}}") @fizz {
-          doThing
-        }
-      `,
-      variables: {
-        id: 123,
-        oid: 'foo',
-      },
+        expect(key).toEqual('bar');
+        expect(operation).not.toBe(origOperation);
     });
-    const { operation, key } = extractKey(origOperation);
 
-    expect(key).toEqual('thing:123:foo');
-    expect(operation).not.toBe(origOperation);
-  });
+    it('removes @serialize from the query document', () => {
+        const origOperation = createOperation(null, {
+            query: gql`
+                mutation doThing @serialize(key: "bar") @fizz {
+                    doThing
+                }
+            `,
+        });
+        const { operation, key } = extractKey(origOperation);
+
+        const operationNode = operation.query.definitions[0] as OperationDefinitionNode;
+        expect(operationNode.directives.length).toEqual(1);
+        expect(operationNode.directives[0].name.value).toEqual('fizz');
+    });
+
+    it('interpolates variables within a string', () => {
+        const origOperation = createOperation(null, {
+            query: gql`
+                mutation doThing($id: Integer, $oid: String) @serialize(key: "thing:{{id}}:{{oid}}") @fizz {
+                    doThing
+                }
+            `,
+            variables: {
+                id: 123,
+                oid: 'foo',
+            },
+        });
+        const { operation, key } = extractKey(origOperation);
+
+        expect(key).toEqual('thing:123:foo');
+        expect(operation).not.toBe(origOperation);
+    });
 });

--- a/src/extractKey.ts
+++ b/src/extractKey.ts
@@ -4,80 +4,80 @@ import { DirectiveNode, ArgumentNode } from 'graphql';
 import deepUpdate = require('deep-update');
 
 export function extractKey(operation: Operation): { operation: Operation, key?: string } {
-  // Explicit keys in the link context win out.
-  const { serializationKey } = operation.getContext();
-  if (serializationKey) {
-      return { operation, key: serializationKey };
-  }
+    // Explicit keys in the link context win out.
+    const { serializationKey } = operation.getContext();
+    if (serializationKey) {
+        return { operation, key: serializationKey };
+    }
 
-  const { directive, path } = extractDirective(operation);
-  if (!directive) {
-      return { operation };
-  }
-  const argument = directive.arguments.find(d => d.name.value === 'key');
-  if (!argument) {
-      throw new Error(`The @serialize directive requires a 'key' argument`);
-  }
-  let key = valueForArgument(argument, operation.variables);
-  // Replace any {{variable}}s with their value.
-  key = key.replace(/\{\{([^\}]+)\}\}/g, (_substring, name) => {
-    return getVariableOrDie(operation.variables, name);
-  });
+    const { directive, path } = extractDirective(operation);
+    if (!directive) {
+        return { operation };
+    }
+    const argument = directive.arguments.find(d => d.name.value === 'key');
+    if (!argument) {
+        throw new Error(`The @serialize directive requires a 'key' argument`);
+    }
+    let key = valueForArgument(argument, operation.variables);
+    // Replace any {{variable}}s with their value.
+    key = key.replace(/\{\{([^\}]+)\}\}/g, (_substring, name) => {
+        return getVariableOrDie(operation.variables, name);
+    });
 
-  // Pass through the operation, with the directive removed so that the server
-  // doesn't see it.
-  const finalIndex = path.pop();
-  const newOperation = createOperation(operation.getContext(), {
-    ...operation as any,
-    query: deepUpdate(operation.query, path, {$splice: [[finalIndex, 1]]}),
-  });
+    // Pass through the operation, with the directive removed so that the server
+    // doesn't see it.
+    const finalIndex = path.pop();
+    const newOperation = createOperation(operation.getContext(), {
+        ...operation as any,
+        query: deepUpdate(operation.query, path, {$splice: [[finalIndex, 1]]}),
+    });
 
-  return { operation: newOperation, key };
+    return { operation: newOperation, key };
 }
 
 function extractDirective({ query, operationName }: Operation): { directive?: DirectiveNode, path?: string[] } {
-  const path: string[] = [];
+    const path: string[] = [];
 
-  // First, find the operation definition
-  let operationNode;
-  for (let i = 0; i < query.definitions.length; i++) {
-      const node = query.definitions[i];
-      if (node.kind !== 'OperationDefinition') {
-          continue;
-      }
-      if (!operationName || node.name.value == operationName) {
-          operationNode = node;
-          path.push('definitions', `${i}`);
-          break;
-      }
-  }
+    // First, find the operation definition
+    let operationNode;
+    for (let i = 0; i < query.definitions.length; i++) {
+        const node = query.definitions[i];
+        if (node.kind !== 'OperationDefinition') {
+            continue;
+        }
+        if (!operationName || node.name.value == operationName) {
+            operationNode = node;
+            path.push('definitions', `${i}`);
+            break;
+        }
+    }
 
-  // Then, the directive itself.
-  for (let i = 0; i < operationNode.directives.length; i++) {
-      const node = operationNode.directives[i];
-      if (node.name.value === 'serialize') {
-          path.push('directives', `${i}`);
-          return { directive: node, path };
-      }
-  }
+    // Then, the directive itself.
+    for (let i = 0; i < operationNode.directives.length; i++) {
+        const node = operationNode.directives[i];
+        if (node.name.value === 'serialize') {
+            path.push('directives', `${i}`);
+            return { directive: node, path };
+        }
+    }
 
-  return {};
+    return {};
 }
 
 export function valueForArgument({ value }: ArgumentNode, variables?: Record<string, any>): string {
-  if (value.kind === 'Variable') {
-    return getVariableOrDie(variables, value.name.value);
-  }
-  if (value.kind !== 'StringValue') {
-    throw new Error(`values for @serialize(key:) must be strings or variables`);
-  }
+    if (value.kind === 'Variable') {
+        return getVariableOrDie(variables, value.name.value);
+    }
+    if (value.kind !== 'StringValue') {
+        throw new Error(`values for @serialize(key:) must be strings or variables`);
+    }
 
-  return value.value;
+    return value.value;
 }
 
 export function getVariableOrDie(variables: Record<string, any> | undefined, name: string): any {
-  if (!variables || !(name in variables)) {
-    throw new Error(`Expected $${name} to exist for @serialize`);
-  }
-  return variables[name];
+    if (!variables || !(name in variables)) {
+        throw new Error(`Expected $${name} to exist for @serialize`);
+    }
+    return variables[name];
 }

--- a/src/extractKey.ts
+++ b/src/extractKey.ts
@@ -1,0 +1,83 @@
+import { createOperation, Operation } from 'apollo-link';
+import { DirectiveNode, ArgumentNode } from 'graphql';
+
+import deepUpdate = require('deep-update');
+
+export function extractKey(operation: Operation): { operation: Operation, key?: string } {
+  // Explicit keys in the link context win out.
+  const { serializationKey } = operation.getContext();
+  if (serializationKey) {
+      return { operation, key: serializationKey };
+  }
+
+  const { directive, path } = extractDirective(operation);
+  if (!directive) {
+      return { operation };
+  }
+  const argument = directive.arguments.find(d => d.name.value === 'key');
+  if (!argument) {
+      throw new Error(`The @serialize directive requires a 'key' argument`);
+  }
+  let key = valueForArgument(argument, operation.variables);
+  // Replace any {{variable}}s with their value.
+  key = key.replace(/\{\{([^\}]+)\}\}/g, (_substring, name) => {
+    return getVariableOrDie(operation.variables, name);
+  });
+
+  // Pass through the operation, with the directive removed so that the server
+  // doesn't see it.
+  const finalIndex = path.pop();
+  const newOperation = createOperation(null, {
+    ...operation as any,
+    query: deepUpdate(operation.query, path, {$splice: [[finalIndex, 1]]}),
+  });
+
+  return { operation: newOperation, key };
+}
+
+function extractDirective({ query, operationName }: Operation): { directive?: DirectiveNode, path?: string[] } {
+  const path: string[] = [];
+
+  // First, find the operation definition
+  let operationNode;
+  for (let i = 0; i < query.definitions.length; i++) {
+      const node = query.definitions[i];
+      if (node.kind !== 'OperationDefinition') {
+          continue;
+      }
+      if (!operationName || node.name.value == operationName) {
+          operationNode = node;
+          path.push('definitions', `${i}`);
+          break;
+      }
+  }
+
+  // Then, the directive itself.
+  for (let i = 0; i < operationNode.directives.length; i++) {
+      const node = operationNode.directives[i];
+      if (node.name.value === 'serialize') {
+          path.push('directives', `${i}`);
+          return { directive: node, path };
+      }
+  }
+
+  return {};
+}
+
+export function valueForArgument({ value }: ArgumentNode, variables?: Record<string, any>): string {
+  if (value.kind === 'Variable') {
+    return getVariableOrDie(variables, value.name.value);
+  }
+  if (value.kind !== 'StringValue') {
+    throw new Error(`values for @serialize(key:) must be strings or variables`);
+  }
+
+  return value.value;
+}
+
+export function getVariableOrDie(variables: Record<string, any> | undefined, name: string): any {
+  if (!variables || !(name in variables)) {
+    throw new Error(`Expected $${name} to exist for @serialize`);
+  }
+  return variables[name];
+}

--- a/src/extractKey.ts
+++ b/src/extractKey.ts
@@ -27,7 +27,7 @@ export function extractKey(operation: Operation): { operation: Operation, key?: 
   // Pass through the operation, with the directive removed so that the server
   // doesn't see it.
   const finalIndex = path.pop();
-  const newOperation = createOperation(null, {
+  const newOperation = createOperation(operation.getContext(), {
     ...operation as any,
     query: deepUpdate(operation.query, path, {$splice: [[finalIndex, 1]]}),
   });


### PR DESCRIPTION
This is an alternative approach to #1 - with the added benefit that the serialization key is explicit per operation, and also co-located, which makes the behavior much easier to reason about.

See the updates to the README for usage notes (I'm hoping those stand on their own as a description for this PR)

Note that this depends on https://github.com/apollographql/apollo-link/pull/331 and cannot be merged until that's published.