### PR TITLE
Bump apollo-link dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "A link that serializes requests by key, making sure that they execute in the exact order submitted",
   "dependencies": {
-    "apollo-link": "^0.7.0"
+    "apollo-link": "^1.0.0"
   },
   "devDependencies": {
     "@types/graphql": "^0.11.7",


### PR DESCRIPTION
The version constraint was out of date, resulting in an extra copy of apollo-link installed just for this package to use.